### PR TITLE
feat: add user internalId, policy approve CTA, centralize user service

### DIFF
--- a/prisma/migrations/20260407000000_add_user_internal_id/migration.sql
+++ b/prisma/migrations/20260407000000_add_user_internal_id/migration.sql
@@ -1,0 +1,11 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN "internalId" INTEGER;
+
+-- Backfill existing users with consecutive IDs ordered by creation date
+WITH ranked AS (
+  SELECT id, ROW_NUMBER() OVER (ORDER BY "createdAt") AS rn FROM "User"
+)
+UPDATE "User" SET "internalId" = ranked.rn FROM ranked WHERE "User".id = ranked.id;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "User_internalId_key" ON "User"("internalId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -26,6 +26,7 @@ model User {
   phone         String?
   address       String?
   isActive      Boolean   @default(true)
+  internalId    Int?      @unique
 
   // Invitation fields
   invitationToken       String?   @unique

--- a/src/app/api/auth/register/route.ts
+++ b/src/app/api/auth/register/route.ts
@@ -1,8 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server';
 import prisma from '@/lib/prisma';
-import { hashPassword, generateToken } from '@/lib/auth';
+import { generateToken } from '@/lib/auth';
 import { z } from 'zod';
-import { UserRole } from "@/prisma/generated/prisma-client/enums";
+import { userService } from '@/lib/services/userService';
 
 const registerSchema = z.object({
   email: z.string().email(),
@@ -36,18 +36,23 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // Hash password and create user
     // Public registration only creates BROKER accounts
     // ADMIN/STAFF accounts must be created via admin invitation
-    const hashedPassword = await hashPassword(password);
-    const user = await prisma.user.create({
-      data: {
-        email,
-        password: hashedPassword,
-        name,
-        role: UserRole.BROKER
-      }
+    const result = await userService.create({
+      email,
+      password,
+      name,
+      role: 'BROKER',
     });
+
+    if (!result.ok) {
+      return NextResponse.json(
+        { error: result.error.message },
+        { status: 400 }
+      );
+    }
+
+    const user = result.value;
 
     // Generate JWT token
     const token = generateToken({
@@ -56,11 +61,8 @@ export async function POST(request: NextRequest) {
       role: user.role
     });
 
-    // Return user data without password
-    const { password: _, ...userWithoutPassword } = user;
-
     return NextResponse.json({
-      user: userWithoutPassword,
+      user,
       token
     }, { status: 201 });
 

--- a/src/app/api/user/avatar/route.ts
+++ b/src/app/api/user/avatar/route.ts
@@ -3,6 +3,7 @@ import { verifyAuth } from '@/lib/auth';
 import { getCurrentStorageProvider, getPublicDownloadUrl } from '@/lib/services/documentService';
 import { validateInvitationToken } from '@/lib/services/userTokenService';
 import prisma from '@/lib/prisma';
+import { userService } from '@/lib/services/userService';
 import { v4 as uuidv4 } from 'uuid';
 
 // Maximum file size: 20MB
@@ -129,16 +130,16 @@ export async function POST(request: NextRequest) {
     });
 
     // Update user's avatar URL in database
-    const updatedUser = await prisma.user.update({
-      where: { id: userId },
-      data: { avatarUrl: uploadedUrl },
-      select: {
-        id: true,
-        name: true,
-        email: true,
-        avatarUrl: true,
-      },
-    });
+    const updateResult = await userService.update(userId, { avatarUrl: uploadedUrl });
+
+    if (!updateResult.ok) {
+      return NextResponse.json(
+        { success: false, error: 'Failed to update avatar URL' },
+        { status: 500 }
+      );
+    }
+
+    const updatedUser = updateResult.value;
 
     // Delete old avatar from S3 (if it exists and is an S3 URL)
     if (currentUser?.avatarUrl) {
@@ -221,21 +222,19 @@ export async function DELETE(request: NextRequest) {
     }
 
     // Clear avatar URL in database
-    const updatedUser = await prisma.user.update({
-      where: { id: userId },
-      data: { avatarUrl: null },
-      select: {
-        id: true,
-        name: true,
-        email: true,
-        avatarUrl: true,
-      },
-    });
+    const updateResult = await userService.update(userId, { avatarUrl: null });
+
+    if (!updateResult.ok) {
+      return NextResponse.json(
+        { success: false, error: 'Failed to clear avatar URL' },
+        { status: 500 }
+      );
+    }
 
     return NextResponse.json({
       success: true,
       message: 'Avatar eliminado correctamente',
-      user: updatedUser,
+      user: updateResult.value,
     });
   } catch {
     return NextResponse.json(

--- a/src/app/dashboard/profile/page.tsx
+++ b/src/app/dashboard/profile/page.tsx
@@ -184,6 +184,7 @@ export default function ProfilePage() {
               </p>
             </CardHeader>
             <CardContent className="text-sm text-muted-foreground space-y-2">
+              <p><strong>ID:</strong> {profile?.internalId ?? 'N/A'}</p>
               <p><strong>{t.pages.profile.email}</strong> {profile?.email}</p>
               <p><strong>{t.pages.profile.phone}</strong> {profile?.phone || 'N/A'}</p>
               <p><strong>{t.pages.profile.address}</strong> {profile?.address || 'N/A'}</p>

--- a/src/app/dashboard/users/page.tsx
+++ b/src/app/dashboard/users/page.tsx
@@ -35,6 +35,7 @@ function UsersSkeleton() {
         <Table>
             <TableHeader>
                 <TableRow>
+                    <TableHead>ID</TableHead>
                     <TableHead>{t.pages.users.tableHeaders.name}</TableHead>
                     <TableHead>{t.pages.users.tableHeaders.email}</TableHead>
                     <TableHead>{t.pages.users.tableHeaders.role}</TableHead>
@@ -45,6 +46,7 @@ function UsersSkeleton() {
             <TableBody>
                 {[...Array(5)].map((_, i) => (
                     <TableRow key={i}>
+                        <TableCell><Skeleton className="h-4 w-8" /></TableCell>
                         <TableCell><Skeleton className="h-4 w-32" /></TableCell>
                         <TableCell><Skeleton className="h-4 w-48" /></TableCell>
                         <TableCell><Skeleton className="h-6 w-24 rounded-full" /></TableCell>
@@ -165,6 +167,7 @@ export default function UsersPage() {
                         <Table>
                             <TableHeader>
                                 <TableRow>
+                                    <TableHead>ID</TableHead>
                                     <TableHead>{t.pages.users.tableHeaders.name}</TableHead>
                                     <TableHead>{t.pages.users.tableHeaders.email}</TableHead>
                                     <TableHead>{t.pages.users.tableHeaders.role}</TableHead>
@@ -175,6 +178,7 @@ export default function UsersPage() {
                             <TableBody>
                                 {users.map((user) => (
                                     <TableRow key={user.id}>
+                                        <TableCell className="text-muted-foreground">{user.internalId ?? '-'}</TableCell>
                                         <TableCell className="font-medium">{user.name}</TableCell>
                                         <TableCell>{user.email}</TableCell>
                                         <TableCell>

--- a/src/components/policies/PolicyDetailsContent/PolicyDetailsContent.tsx
+++ b/src/components/policies/PolicyDetailsContent/PolicyDetailsContent.tsx
@@ -133,6 +133,7 @@ export default function PolicyDetailsContent({
     downloadingPdf,
     downloadingDocx,
     pendingAction,
+    isApproving,
     handleSendInvitations,
     sendIndividualInvitation,
     approvePolicy,
@@ -154,6 +155,21 @@ export default function PolicyDetailsContent({
   ) ?? [];
   const completedPayments = activePayments.filter((p: { status: string }) => p.status === 'COMPLETED').length;
   const totalPayments = activePayments.length;
+
+  // Check if all actors have their information complete
+  const allActorsComplete = (() => {
+    const tenant = policy.tenant;
+    const landlords = policy.landlords ?? [];
+    const jointObligors = policy.jointObligors ?? [];
+    const avals = policy.avals ?? [];
+
+    if (!tenant?.informationComplete) return false;
+    if (landlords.length === 0 || !landlords.every((l: { informationComplete: boolean }) => l.informationComplete)) return false;
+    if (!jointObligors.every((jo: { informationComplete: boolean }) => jo.informationComplete)) return false;
+    if (!avals.every((a: { informationComplete: boolean }) => a.informationComplete)) return false;
+
+    return true;
+  })();
 
   // Handle tab change with skeleton loading + URL persistence
   const handleTabChange = (value: string) => {
@@ -225,6 +241,8 @@ export default function PolicyDetailsContent({
           downloadingPdf={downloadingPdf}
           downloadingDocx={downloadingDocx}
           isRefreshing={isRefreshing}
+          allActorsComplete={allActorsComplete}
+          isApproving={isApproving}
           onSendInvitations={handleSendInvitations}
           onApprove={approvePolicy}
           onShareClick={() => setShowShareModal(true)}

--- a/src/components/policies/PolicyDetailsContent/components/PolicyHeader.tsx
+++ b/src/components/policies/PolicyDetailsContent/components/PolicyHeader.tsx
@@ -42,6 +42,8 @@ interface PolicyHeaderProps {
   downloadingPdf: boolean;
   downloadingDocx: boolean;
   isRefreshing?: boolean;
+  allActorsComplete?: boolean;
+  isApproving?: boolean;
   onSendInvitations: () => void;
   onApprove: () => void;
   onShareClick: () => void;
@@ -62,6 +64,8 @@ export function PolicyHeader({
   downloadingPdf,
   downloadingDocx,
   isRefreshing,
+  allActorsComplete,
+  isApproving,
   onSendInvitations,
   onApprove,
   onShareClick,
@@ -97,6 +101,22 @@ export function PolicyHeader({
       </div>
 
       <div className="flex items-center gap-2">
+        {/* Prominent Approve Button — staff/admin only, COLLECTING_INFO, all actors complete */}
+        {isStaffOrAdmin && status === 'COLLECTING_INFO' && allActorsComplete && (
+          <Button
+            onClick={onApprove}
+            disabled={isApproving}
+            className="bg-green-600 hover:bg-green-700 text-white shrink-0"
+          >
+            {isApproving ? (
+              <RefreshCw className="mr-2 h-4 w-4 animate-spin" />
+            ) : (
+              <CheckCircle2 className="mr-2 h-4 w-4" />
+            )}
+            {t.pages.policies.approvePolicy}
+          </Button>
+        )}
+
         {/* Refresh Button */}
         {onRefresh && (
           <Button

--- a/src/lib/services/policyWorkflowService.ts
+++ b/src/lib/services/policyWorkflowService.ts
@@ -11,7 +11,7 @@ import { addMonths } from 'date-fns';
  * COLLECTING_INFO → PENDING_APPROVAL → ACTIVE → EXPIRED | CANCELLED
  */
 const ALLOWED_TRANSITIONS: Record<PolicyStatus, PolicyStatus[]> = {
-  COLLECTING_INFO: ['PENDING_APPROVAL', 'CANCELLED'],
+  COLLECTING_INFO: ['PENDING_APPROVAL', 'ACTIVE', 'CANCELLED'],
   PENDING_APPROVAL: ['ACTIVE', 'COLLECTING_INFO', 'CANCELLED'],
   ACTIVE: ['EXPIRED', 'CANCELLED'],
   EXPIRED: ['CANCELLED'],
@@ -84,6 +84,37 @@ class PolicyWorkflowService extends BaseService {
   }
 
   /**
+   * Check if all actors (tenant, landlords, joint obligors, avals) have their info complete.
+   */
+  async checkAllActorsInfoComplete(policyId: string): Promise<boolean> {
+    const policy = await this.prisma.policy.findUnique({
+      where: { id: policyId },
+      select: {
+        tenant: { select: { informationComplete: true } },
+        landlords: { select: { informationComplete: true } },
+        jointObligors: { select: { informationComplete: true } },
+        avals: { select: { informationComplete: true } },
+      },
+    });
+
+    if (!policy) return false;
+
+    // Must have at least a tenant
+    if (!policy.tenant) return false;
+    if (!policy.tenant.informationComplete) return false;
+
+    // Must have at least one landlord
+    if (policy.landlords.length === 0) return false;
+    if (!policy.landlords.every(l => l.informationComplete)) return false;
+
+    // All joint obligors and avals must be complete (if any exist)
+    if (!policy.jointObligors.every(jo => jo.informationComplete)) return false;
+    if (!policy.avals.every(a => a.informationComplete)) return false;
+
+    return true;
+  }
+
+  /**
    * Check if all active payments for a policy are settled (COMPLETED).
    * Returns true if no active payments exist or all are COMPLETED.
    */
@@ -105,6 +136,7 @@ class PolicyWorkflowService extends BaseService {
    */
   private async validateStatusRequirements(
     policy: { id: string },
+    fromStatus: PolicyStatus,
     newStatus: PolicyStatus
   ): Promise<{ valid: boolean; error?: string }> {
     switch (newStatus) {
@@ -120,12 +152,24 @@ class PolicyWorkflowService extends BaseService {
       }
 
       case 'ACTIVE': {
-        const settled = await this.areAllPaymentsSettled(policy.id);
-        if (!settled) {
-          return {
-            valid: false,
-            error: 'Todos los pagos deben estar completados antes de activar la protección',
-          };
+        if (fromStatus === 'COLLECTING_INFO') {
+          // Direct approval: only requires all actors' info to be complete
+          const allComplete = await this.checkAllActorsInfoComplete(policy.id);
+          if (!allComplete) {
+            return {
+              valid: false,
+              error: 'Toda la información de los actores debe estar completa antes de aprobar la protección',
+            };
+          }
+        } else {
+          // From PENDING_APPROVAL: requires payments settled
+          const settled = await this.areAllPaymentsSettled(policy.id);
+          if (!settled) {
+            return {
+              valid: false,
+              error: 'Todos los pagos deben estar completados antes de activar la protección',
+            };
+          }
         }
         break;
       }
@@ -166,7 +210,7 @@ class PolicyWorkflowService extends BaseService {
     }
 
     // Additional validation based on status
-    const validation = await this.validateStatusRequirements(policy, newStatus);
+    const validation = await this.validateStatusRequirements(policy, policy.status, newStatus);
     if (!validation.valid) {
       return { success: false, error: validation.error };
     }
@@ -414,6 +458,7 @@ export const policyWorkflowService = new PolicyWorkflowService();
 export const isTransitionAllowed = policyWorkflowService.isTransitionAllowed.bind(policyWorkflowService);
 export const getAllowedNextStatuses = policyWorkflowService.getAllowedNextStatuses.bind(policyWorkflowService);
 export const checkAllInvestigationsApproved = policyWorkflowService.checkAllInvestigationsApproved.bind(policyWorkflowService);
+export const checkAllActorsInfoComplete = policyWorkflowService.checkAllActorsInfoComplete.bind(policyWorkflowService);
 export const transitionPolicyStatus = policyWorkflowService.transitionPolicyStatus.bind(policyWorkflowService);
 export const tryAutoTransition = policyWorkflowService.tryAutoTransition.bind(policyWorkflowService);
 export const expireActivePolicies = policyWorkflowService.expireActivePolicies.bind(policyWorkflowService);

--- a/src/lib/services/userService.ts
+++ b/src/lib/services/userService.ts
@@ -7,13 +7,19 @@ import { BaseService, ICrudService, ServiceOptions } from './base/BaseService';
 import { Result, AsyncResult } from './types/result';
 import { ServiceError, ErrorCode, Errors } from './types/errors';
 import { hashPassword } from '../auth';
+import prisma from '../prisma';
 
 // Types
 export interface User {
   id: string;
+  internalId: number | null;
   email: string;
   name: string | null;
+  phone: string | null;
+  address: string | null;
+  avatarUrl: string | null;
   role: string;
+  isActive: boolean;
   createdAt: Date;
   updatedAt: Date;
 }
@@ -30,6 +36,11 @@ export interface UpdateUserDTO {
   name?: string;
   password?: string;
   role?: 'ADMIN' | 'STAFF' | 'BROKER';
+  phone?: string;
+  address?: string;
+  avatarUrl?: string | null;
+  isActive?: boolean;
+  emailVerified?: Date;
 }
 
 export interface UserFilterDTO {
@@ -54,12 +65,25 @@ export interface PaginatedUsers {
 // Select fields to exclude password
 const userSelect = {
   id: true,
+  internalId: true,
   email: true,
   name: true,
+  phone: true,
+  address: true,
+  avatarUrl: true,
   role: true,
+  isActive: true,
   createdAt: true,
   updatedAt: true,
 } as const;
+
+/**
+ * Get the next consecutive internalId for a new user.
+ */
+export async function getNextInternalId(): Promise<number> {
+  const result = await prisma.user.aggregate({ _max: { internalId: true } });
+  return (result._max.internalId ?? 0) + 1;
+}
 
 class UserService extends BaseService implements ICrudService<User, CreateUserDTO, UpdateUserDTO, UserFilterDTO> {
   constructor(options: ServiceOptions = {}) {
@@ -129,6 +153,8 @@ class UserService extends BaseService implements ICrudService<User, CreateUserDT
     // Hash password if provided
     const hashedPassword = data.password ? await hashPassword(data.password) : null;
 
+    const internalId = await getNextInternalId();
+
     return this.executeDbOperation(
       () => this.prisma.user.create({
         data: {
@@ -137,6 +163,7 @@ class UserService extends BaseService implements ICrudService<User, CreateUserDT
           password: hashedPassword,
           role: data.role || 'STAFF',
           isActive: true,
+          internalId,
         },
         select: userSelect,
       }),
@@ -152,6 +179,11 @@ class UserService extends BaseService implements ICrudService<User, CreateUserDT
     if (data.email !== undefined) updateData.email = data.email;
     if (data.name !== undefined) updateData.name = data.name;
     if (data.role !== undefined) updateData.role = data.role;
+    if (data.phone !== undefined) updateData.phone = data.phone;
+    if (data.address !== undefined) updateData.address = data.address;
+    if (data.avatarUrl !== undefined) updateData.avatarUrl = data.avatarUrl;
+    if (data.isActive !== undefined) updateData.isActive = data.isActive;
+    if (data.emailVerified !== undefined) updateData.emailVerified = data.emailVerified;
     if (hashedPassword) updateData.password = hashedPassword;
 
     return this.executeDbOperation(
@@ -168,6 +200,19 @@ class UserService extends BaseService implements ICrudService<User, CreateUserDT
     const result = await this.executeDbOperation(
       () => this.prisma.user.delete({ where: { id } }),
       'delete'
+    );
+
+    if (!result.ok) return result;
+    return Result.ok(true);
+  }
+
+  async softDelete(id: string): AsyncResult<boolean> {
+    const result = await this.executeDbOperation(
+      () => this.prisma.user.update({
+        where: { id },
+        data: { isActive: false },
+      }),
+      'softDelete'
     );
 
     if (!result.ok) return result;
@@ -253,6 +298,12 @@ export const updateUser = async (id: string, data: UpdateUserDTO) => {
 
 export const deleteUser = async (id: string) => {
   const result = await userService.delete(id);
+  if (!result.ok) throw result.error;
+  return result.value;
+};
+
+export const softDeleteUser = async (id: string) => {
+  const result = await userService.softDelete(id);
   if (!result.ok) throw result.error;
   return result.value;
 };

--- a/src/server/routers/onboard.router.ts
+++ b/src/server/routers/onboard.router.ts
@@ -6,7 +6,7 @@ import {
 import { prisma } from '@/lib/prisma';
 import { TRPCError } from '@trpc/server';
 import { validateInvitationToken, clearInvitationToken } from '@/lib/services/userTokenService';
-import { hashPassword } from '@/lib/auth';
+import { userService } from '@/lib/services/userService';
 import { getCurrentStorageProvider, getPublicDownloadUrl } from '@/lib/services/documentService';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -100,19 +100,20 @@ export const onboardRouter = createTRPCRouter({
         });
       }
 
-      // Hash the password
-      const hashedPassword = await hashPassword(password);
-
-      // Update user with password and profile info
-      const updatedUser = await prisma.user.update({
-        where: { id: user.id },
-        data: {
-          password: hashedPassword,
-          phone: phone || user.phone,
-          address: address || user.address,
-          emailVerified: new Date(), // Mark email as verified
-        },
+      // Update user with password and profile info (service handles hashing)
+      const result = await userService.update(user.id, {
+        password,
+        phone: phone || user.phone || undefined,
+        address: address || user.address || undefined,
+        emailVerified: new Date(),
       });
+
+      if (!result.ok) {
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          message: result.error.message,
+        });
+      }
 
       // Clear the invitation token
       await clearInvitationToken(user.id);
@@ -120,10 +121,10 @@ export const onboardRouter = createTRPCRouter({
       return {
         message: 'Account setup completed successfully',
         user: {
-          id: updatedUser.id,
-          name: updatedUser.name,
-          email: updatedUser.email,
-          role: updatedUser.role,
+          id: result.value.id,
+          name: result.value.name,
+          email: result.value.email,
+          role: result.value.role,
         },
       };
     }),
@@ -239,15 +240,18 @@ export const onboardRouter = createTRPCRouter({
       }
 
       // Update user's avatar URL
-      const updatedUser = await prisma.user.update({
-        where: { id: userId },
-        data: { avatarUrl: avatarUrl },
-        select: { id: true, avatarUrl: true },
-      });
+      const result = await userService.update(userId, { avatarUrl });
+
+      if (!result.ok) {
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          message: result.error.message,
+        });
+      }
 
       return {
         success: true,
-        avatarUrl: updatedUser.avatarUrl,
+        avatarUrl: result.value.avatarUrl,
       };
     }),
 });

--- a/src/server/routers/staff.router.ts
+++ b/src/server/routers/staff.router.ts
@@ -7,6 +7,7 @@ import { prisma } from '@/lib/prisma';
 import { TRPCError } from '@trpc/server';
 import { generateInvitationToken } from '@/lib/services/userTokenService';
 import { sendUserInvitation } from '@/lib/services/emailService';
+import { userService } from '@/lib/services/userService';
 
 const ListStaffSchema = z.object({
   page: z.number().int().min(1).default(1),
@@ -57,6 +58,7 @@ export const staffRouter = createTRPCRouter({
           where,
           select: {
             id: true,
+            internalId: true,
             email: true,
             name: true,
             role: true,
@@ -92,6 +94,7 @@ export const staffRouter = createTRPCRouter({
         where: { id: input.id },
         select: {
           id: true,
+          internalId: true,
           email: true,
           name: true,
           role: true,
@@ -133,22 +136,16 @@ export const staffRouter = createTRPCRouter({
       }
 
       // Create user without password - they'll set it via invitation
-      const newUser = await prisma.user.create({
-        data: {
-          email,
-          name,
-          role,
-          isActive: true,
-        },
-        select: {
-          id: true,
-          email: true,
-          name: true,
-          role: true,
-          createdAt: true,
-          updatedAt: true,
-        },
-      });
+      const result = await userService.create({ email, name, role });
+
+      if (!result.ok) {
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          message: result.error.message,
+        });
+      }
+
+      const newUser = result.value;
 
       // Generate invitation token
       const token = await generateInvitationToken(newUser.id);
@@ -207,21 +204,16 @@ export const staffRouter = createTRPCRouter({
         });
       }
 
-      const updatedUser = await prisma.user.update({
-        where: { id },
-        data,
-        select: {
-          id: true,
-          email: true,
-          name: true,
-          role: true,
-          avatarUrl: true,
-          createdAt: true,
-          updatedAt: true,
-        },
-      });
+      const result = await userService.update(id, data);
 
-      return updatedUser;
+      if (!result.ok) {
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          message: result.error.message,
+        });
+      }
+
+      return result.value;
     }),
 
   /**
@@ -252,10 +244,14 @@ export const staffRouter = createTRPCRouter({
       }
 
       // Soft delete - set isActive to false
-      await prisma.user.update({
-        where: { id: input.id },
-        data: { isActive: false },
-      });
+      const result = await userService.softDelete(input.id);
+
+      if (!result.ok) {
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          message: result.error.message,
+        });
+      }
 
       return { success: true };
     }),

--- a/src/server/routers/user.router.ts
+++ b/src/server/routers/user.router.ts
@@ -6,6 +6,7 @@ import {
 import { prisma } from '@/lib/prisma';
 import bcrypt from 'bcryptjs';
 import { getCurrentStorageProvider, getPublicDownloadUrl } from '@/lib/services/documentService';
+import { userService } from '@/lib/services/userService';
 import { v4 as uuidv4 } from 'uuid';
 import {
   throwNotFound,
@@ -44,6 +45,7 @@ export const userRouter = createTRPCRouter({
         where: { id: ctx.userId },
         select: {
           id: true,
+          internalId: true,
           name: true,
           email: true,
           phone: true,
@@ -78,15 +80,12 @@ export const userRouter = createTRPCRouter({
         throwNotFound('User', ctx.userId);
       }
 
-      const dataToUpdate: Record<string, unknown> = { ...profileData };
-
       // Handle email change
       if (email && email !== user.email) {
         const existingUser = await prisma.user.findUnique({ where: { email } });
         if (existingUser) {
           throwConflict('Email');
         }
-        dataToUpdate.email = email;
       }
 
       // Handle password change
@@ -101,25 +100,19 @@ export const userRouter = createTRPCRouter({
         if (!isPasswordValid) {
           throwValidationError('Invalid current password');
         }
-        dataToUpdate.password = await bcrypt.hash(newPassword, 10);
       }
 
-      const updatedUser = await prisma.user.update({
-        where: { id: ctx.userId },
-        data: dataToUpdate,
-        select: {
-          id: true,
-          name: true,
-          email: true,
-          phone: true,
-          address: true,
-          avatarUrl: true,
-          role: true,
-          createdAt: true,
-        },
+      const result = await userService.update(ctx.userId, {
+        ...profileData,
+        ...(email && email !== user.email ? { email } : {}),
+        ...(newPassword ? { password: newPassword } : {}),
       });
 
-      return updatedUser;
+      if (!result.ok) {
+        throwInternalError(result.error.message);
+      }
+
+      return result.value;
     }),
 
   /**
@@ -200,21 +193,16 @@ export const userRouter = createTRPCRouter({
       }
 
       // Update user's avatar URL
-      const updatedUser = await prisma.user.update({
-        where: { id: userId },
-        data: { avatarUrl },
-        select: {
-          id: true,
-          name: true,
-          email: true,
-          avatarUrl: true,
-        },
-      });
+      const result = await userService.update(userId, { avatarUrl });
+
+      if (!result.ok) {
+        throwInternalError('Failed to update avatar');
+      }
 
       return {
         success: true,
-        avatarUrl: updatedUser.avatarUrl,
-        user: updatedUser,
+        avatarUrl: result.value.avatarUrl,
+        user: result.value,
       };
     }),
 
@@ -223,19 +211,13 @@ export const userRouter = createTRPCRouter({
    */
   deleteAvatar: protectedProcedure
     .mutation(async ({ ctx }) => {
-      // TODO: Implement AWS S3 delete when AWS utilities are available
-      const updatedUser = await prisma.user.update({
-        where: { id: ctx.userId },
-        data: { avatarUrl: null },
-        select: {
-          id: true,
-          name: true,
-          email: true,
-          avatarUrl: true,
-        },
-      });
+      const result = await userService.update(ctx.userId, { avatarUrl: null });
 
-      return updatedUser;
+      if (!result.ok) {
+        throwInternalError('Failed to delete avatar');
+      }
+
+      return result.value;
     }),
 
   /**


### PR DESCRIPTION
- Add consecutive `internalId` field to User model with migration + backfill
- Display internalId on profile page and user management table
- Add prominent "Aprobar Protección" CTA for staff/admin when all actors' info is complete (COLLECTING_INFO → ACTIVE)
- Centralize all user create/update/delete through UserService — no more direct prisma.user calls in routers
- Extend UserService with phone, address, avatarUrl, isActive, emailVerified support and softDelete()